### PR TITLE
Implement persistent DB-backed activity storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,33 @@ Remember, it's self-paced so feel free to take a break! ☕️
 
 [![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/joergjo/skills-integrate-mcp-with-copilot/issues/1)
 
+## Local Development
+
+1. Install dependencies:
+
+	```bash
+	pip install -r requirements.txt
+	```
+
+2. Run the API from `src/`:
+
+	```bash
+	cd src
+	uvicorn app:app --reload
+	```
+
+3. Run tests from repository root:
+
+	```bash
+	pytest
+	```
+
+### Persistence and Migration Notes
+
+- The application now uses SQLite (`src/mergington.db`) for persistence.
+- Schema migrations are applied automatically on startup.
+- Initial sample data is seeded if the activities table is empty.
+
 ---
 
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+pytest
+httpx

--- a/src/README.md
+++ b/src/README.md
@@ -1,24 +1,26 @@
 # Mergington High School Activities API
 
-A super simple FastAPI application that allows students to view and sign up for extracurricular activities.
+A FastAPI application that allows students to view and sign up for extracurricular activities.
 
 ## Features
 
 - View all available extracurricular activities
 - Sign up for activities
+- Unregister from activities
+- Persist activities and registrations in SQLite
 
 ## Getting Started
 
 1. Install the dependencies:
 
    ```
-   pip install fastapi uvicorn
+   pip install -r ../requirements.txt
    ```
 
 2. Run the application:
 
    ```
-   python app.py
+   uvicorn app:app --reload
    ```
 
 3. Open your browser and go to:
@@ -31,6 +33,20 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+
+## Database and Migrations
+
+The app uses a SQLite database at `src/mergington.db` by default.
+
+- On startup, schema migrations are applied automatically.
+- If the activities table is empty, seed data equivalent to the original in-memory sample is inserted.
+
+Schema tables:
+
+- `users`
+- `activities`
+- `registrations`
+- `schema_migrations`
 
 ## Data Model
 
@@ -47,4 +63,12 @@ The application uses a simple data model with meaningful identifiers:
    - Name
    - Grade level
 
-All data is stored in memory, which means data will be reset when the server restarts.
+All activity and registration data is stored in SQLite, so data is preserved across app restarts.
+
+## Running Tests
+
+From the repository root:
+
+```
+pytest
+```

--- a/src/app.py
+++ b/src/app.py
@@ -1,132 +1,69 @@
-"""
-High School Management System API
+"""High School Management System API."""
 
-A super simple FastAPI application that allows students to view and sign up
-for extracurricular activities at Mergington High School.
-"""
-
-from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
-import os
 from pathlib import Path
 
-app = FastAPI(title="Mergington High School API",
-              description="API for viewing and signing up for extracurricular activities")
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import RedirectResponse
+from fastapi.staticfiles import StaticFiles
 
-# Mount the static files directory
-current_dir = Path(__file__).parent
-app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
-          "static")), name="static")
-
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+try:
+    from .db import DEFAULT_DB_PATH, initialize_database, seed_database_if_empty
+    from .repository import (
+        ActivityNotFoundError,
+        ActivityRepository,
+        RegistrationError,
+    )
+except ImportError:
+    from db import DEFAULT_DB_PATH, initialize_database, seed_database_if_empty
+    from repository import ActivityNotFoundError, ActivityRepository, RegistrationError
 
 
-@app.get("/")
-def root():
-    return RedirectResponse(url="/static/index.html")
+def create_app(db_path: Path | None = None) -> FastAPI:
+    app = FastAPI(
+        title="Mergington High School API",
+        description="API for viewing and signing up for extracurricular activities",
+    )
+
+    repository = ActivityRepository(db_path or DEFAULT_DB_PATH)
+    static_dir = Path(__file__).parent / "static"
+    app.mount("/static", StaticFiles(directory=static_dir), name="static")
+
+    @app.on_event("startup")
+    def setup_database() -> None:
+        initialize_database(repository.db_path)
+        seed_database_if_empty(repository.db_path)
+
+    @app.get("/")
+    def root() -> RedirectResponse:
+        return RedirectResponse(url="/static/index.html")
+
+    @app.get("/activities")
+    def get_activities() -> dict[str, dict[str, object]]:
+        return repository.list_activities()
+
+    @app.post("/activities/{activity_name}/signup")
+    def signup_for_activity(activity_name: str, email: str) -> dict[str, str]:
+        try:
+            repository.signup(activity_name, email)
+        except ActivityNotFoundError:
+            raise HTTPException(status_code=404, detail="Activity not found") from None
+        except RegistrationError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from None
+
+        return {"message": f"Signed up {email} for {activity_name}"}
+
+    @app.delete("/activities/{activity_name}/unregister")
+    def unregister_from_activity(activity_name: str, email: str) -> dict[str, str]:
+        try:
+            repository.unregister(activity_name, email)
+        except ActivityNotFoundError:
+            raise HTTPException(status_code=404, detail="Activity not found") from None
+        except RegistrationError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from None
+
+        return {"message": f"Unregistered {email} from {activity_name}"}
+
+    return app
 
 
-@app.get("/activities")
-def get_activities():
-    return activities
-
-
-@app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
-
-    # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
-
-
-@app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+app = create_app()

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,193 @@
+"""Database setup, migrations, and seed data for Mergington API."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+DEFAULT_DB_PATH = Path(__file__).parent / "mergington.db"
+
+SEED_ACTIVITIES = [
+    {
+        "name": "Chess Club",
+        "description": "Learn strategies and compete in chess tournaments",
+        "schedule": "Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 12,
+        "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
+    },
+    {
+        "name": "Programming Class",
+        "description": "Learn programming fundamentals and build software projects",
+        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+        "max_participants": 20,
+        "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
+    },
+    {
+        "name": "Gym Class",
+        "description": "Physical education and sports activities",
+        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+        "max_participants": 30,
+        "participants": ["john@mergington.edu", "olivia@mergington.edu"],
+    },
+    {
+        "name": "Soccer Team",
+        "description": "Join the school soccer team and compete in matches",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"],
+    },
+    {
+        "name": "Basketball Team",
+        "description": "Practice and play basketball with the school team",
+        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"],
+    },
+    {
+        "name": "Art Club",
+        "description": "Explore your creativity through painting and drawing",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
+    },
+    {
+        "name": "Drama Club",
+        "description": "Act, direct, and produce plays and performances",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
+    },
+    {
+        "name": "Math Club",
+        "description": "Solve challenging problems and participate in math competitions",
+        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 10,
+        "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
+    },
+    {
+        "name": "Debate Team",
+        "description": "Develop public speaking and argumentation skills",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 12,
+        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+    },
+]
+
+MIGRATIONS: list[tuple[str, str]] = [
+    (
+        "001_initial_schema",
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            email TEXT NOT NULL UNIQUE,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE TABLE IF NOT EXISTS activities (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE,
+            description TEXT NOT NULL,
+            schedule TEXT NOT NULL,
+            max_participants INTEGER NOT NULL CHECK(max_participants > 0),
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE TABLE IF NOT EXISTS registrations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            activity_id INTEGER NOT NULL,
+            user_id INTEGER NOT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(activity_id, user_id),
+            FOREIGN KEY(activity_id) REFERENCES activities(id) ON DELETE CASCADE,
+            FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_registrations_activity_id
+        ON registrations(activity_id);
+
+        CREATE INDEX IF NOT EXISTS idx_registrations_user_id
+        ON registrations(user_id);
+        """,
+    )
+]
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    return connection
+
+
+def initialize_database(db_path: Path = DEFAULT_DB_PATH) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with _connect(db_path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                migration_name TEXT PRIMARY KEY,
+                applied_at TEXT DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+
+        applied = {
+            row["migration_name"]
+            for row in connection.execute("SELECT migration_name FROM schema_migrations")
+        }
+
+        for name, sql in MIGRATIONS:
+            if name in applied:
+                continue
+            connection.executescript(sql)
+            connection.execute(
+                "INSERT INTO schema_migrations (migration_name) VALUES (?)",
+                (name,),
+            )
+
+        connection.commit()
+
+
+def seed_database_if_empty(db_path: Path = DEFAULT_DB_PATH) -> None:
+    with _connect(db_path) as connection:
+        existing_activity_count = connection.execute(
+            "SELECT COUNT(*) AS count FROM activities"
+        ).fetchone()["count"]
+
+        if existing_activity_count > 0:
+            return
+
+        for activity in SEED_ACTIVITIES:
+            cursor = connection.execute(
+                """
+                INSERT INTO activities (name, description, schedule, max_participants)
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    activity["name"],
+                    activity["description"],
+                    activity["schedule"],
+                    activity["max_participants"],
+                ),
+            )
+            activity_id = cursor.lastrowid
+
+            for email in activity["participants"]:
+                connection.execute(
+                    "INSERT OR IGNORE INTO users (email) VALUES (?)",
+                    (email,),
+                )
+                user_id = connection.execute(
+                    "SELECT id FROM users WHERE email = ?",
+                    (email,),
+                ).fetchone()["id"]
+                connection.execute(
+                    """
+                    INSERT INTO registrations (activity_id, user_id)
+                    VALUES (?, ?)
+                    """,
+                    (activity_id, user_id),
+                )
+
+        connection.commit()

--- a/src/repository.py
+++ b/src/repository.py
@@ -1,0 +1,128 @@
+"""Data access layer for activities and registrations."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+class ActivityNotFoundError(Exception):
+    """Raised when an activity does not exist."""
+
+
+class RegistrationError(Exception):
+    """Raised when a registration operation is invalid."""
+
+
+class ActivityRepository:
+    def __init__(self, db_path: Path):
+        self.db_path = Path(db_path)
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.db_path)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        return connection
+
+    def list_activities(self) -> dict[str, dict[str, object]]:
+        with self._connect() as connection:
+            activity_rows = connection.execute(
+                """
+                SELECT id, name, description, schedule, max_participants
+                FROM activities
+                ORDER BY id
+                """
+            ).fetchall()
+
+            result: dict[str, dict[str, object]] = {}
+            for row in activity_rows:
+                participants = connection.execute(
+                    """
+                    SELECT users.email
+                    FROM registrations
+                    JOIN users ON users.id = registrations.user_id
+                    WHERE registrations.activity_id = ?
+                    ORDER BY registrations.id
+                    """,
+                    (row["id"],),
+                ).fetchall()
+
+                result[row["name"]] = {
+                    "description": row["description"],
+                    "schedule": row["schedule"],
+                    "max_participants": row["max_participants"],
+                    "participants": [participant["email"] for participant in participants],
+                }
+
+            return result
+
+    def signup(self, activity_name: str, email: str) -> None:
+        with self._connect() as connection:
+            activity = connection.execute(
+                "SELECT id FROM activities WHERE name = ?",
+                (activity_name,),
+            ).fetchone()
+            if activity is None:
+                raise ActivityNotFoundError()
+
+            connection.execute(
+                "INSERT OR IGNORE INTO users (email) VALUES (?)",
+                (email,),
+            )
+            user = connection.execute(
+                "SELECT id FROM users WHERE email = ?",
+                (email,),
+            ).fetchone()
+
+            existing_registration = connection.execute(
+                """
+                SELECT id
+                FROM registrations
+                WHERE activity_id = ? AND user_id = ?
+                """,
+                (activity["id"], user["id"]),
+            ).fetchone()
+            if existing_registration is not None:
+                raise RegistrationError("Student is already signed up")
+
+            connection.execute(
+                """
+                INSERT INTO registrations (activity_id, user_id)
+                VALUES (?, ?)
+                """,
+                (activity["id"], user["id"]),
+            )
+            connection.commit()
+
+    def unregister(self, activity_name: str, email: str) -> None:
+        with self._connect() as connection:
+            activity = connection.execute(
+                "SELECT id FROM activities WHERE name = ?",
+                (activity_name,),
+            ).fetchone()
+            if activity is None:
+                raise ActivityNotFoundError()
+
+            user = connection.execute(
+                "SELECT id FROM users WHERE email = ?",
+                (email,),
+            ).fetchone()
+            if user is None:
+                raise RegistrationError("Student is not signed up for this activity")
+
+            registration = connection.execute(
+                """
+                SELECT id
+                FROM registrations
+                WHERE activity_id = ? AND user_id = ?
+                """,
+                (activity["id"], user["id"]),
+            ).fetchone()
+            if registration is None:
+                raise RegistrationError("Student is not signed up for this activity")
+
+            connection.execute(
+                "DELETE FROM registrations WHERE id = ?",
+                (registration["id"],),
+            )
+            connection.commit()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from src.app import create_app
+from src.db import initialize_database, seed_database_if_empty
+
+
+def _new_client(db_path: Path) -> TestClient:
+    app = create_app(db_path=db_path)
+    return TestClient(app)
+
+
+def test_get_activities_returns_seed_data(tmp_path: Path) -> None:
+    db_path = tmp_path / "test.db"
+
+    with _new_client(db_path) as client:
+        response = client.get("/activities")
+
+    assert response.status_code == 200
+    activities = response.json()
+    assert "Chess Club" in activities
+    assert activities["Chess Club"]["participants"] == [
+        "michael@mergington.edu",
+        "daniel@mergington.edu",
+    ]
+
+
+def test_signup_and_unregister_flow(tmp_path: Path) -> None:
+    db_path = tmp_path / "test.db"
+
+    with _new_client(db_path) as client:
+        signup_response = client.post(
+            "/activities/Chess Club/signup",
+            params={"email": "newstudent@mergington.edu"},
+        )
+        assert signup_response.status_code == 200
+
+        duplicate_response = client.post(
+            "/activities/Chess Club/signup",
+            params={"email": "newstudent@mergington.edu"},
+        )
+        assert duplicate_response.status_code == 400
+        assert duplicate_response.json()["detail"] == "Student is already signed up"
+
+        unregister_response = client.delete(
+            "/activities/Chess Club/unregister",
+            params={"email": "newstudent@mergington.edu"},
+        )
+        assert unregister_response.status_code == 200
+
+        missing_response = client.delete(
+            "/activities/Chess Club/unregister",
+            params={"email": "newstudent@mergington.edu"},
+        )
+        assert missing_response.status_code == 400
+        assert (
+            missing_response.json()["detail"]
+            == "Student is not signed up for this activity"
+        )
+
+
+def test_data_persists_after_restart(tmp_path: Path) -> None:
+    db_path = tmp_path / "test.db"
+
+    with _new_client(db_path) as client:
+        response = client.post(
+            "/activities/Programming%20Class/signup",
+            params={"email": "persisted@mergington.edu"},
+        )
+        assert response.status_code == 200
+
+    # Simulate app restart by creating a new app and TestClient on the same DB.
+    with _new_client(db_path) as new_client:
+        activities_response = new_client.get("/activities")
+
+    participants = activities_response.json()["Programming Class"]["participants"]
+    assert "persisted@mergington.edu" in participants
+
+
+def test_seed_is_idempotent(tmp_path: Path) -> None:
+    db_path = tmp_path / "test.db"
+
+    initialize_database(db_path)
+    seed_database_if_empty(db_path)
+    seed_database_if_empty(db_path)
+
+    with _new_client(db_path) as client:
+        activities = client.get("/activities").json()
+
+    assert len(activities) == 9


### PR DESCRIPTION
## Summary
- replace in-memory activities data with SQLite-backed persistence
- add startup migrations and idempotent seed data
- add repository/data-access layer for activities and registrations
- keep endpoint behavior parity for list/signup/unregister
- add tests for CRUD flow, persistence across restarts, and seed idempotency
- document setup, migrations, and test workflow

## Testing
- `/usr/local/bin/python -m pytest -q`

Closes #9